### PR TITLE
Fix Nextcloud term usage

### DIFF
--- a/_includes/home.html
+++ b/_includes/home.html
@@ -207,10 +207,10 @@
           <div class="media align-items-center mb-2">
             <img src="/assets/svg/icons/nextcloud.svg" style="margin-right: 24px;margin-top: 10px;" alt="Example diagram" width="42px" height="42px">
             <div class="media-body">
-              <h4 class="h6 mb-0">NextCloud</h4>
+              <h4 class="h6 mb-0">Nextcloud</h4>
             </div>
           </div>
-          <p>NextCloud is an ideal on-premise file hosting system for diagrams.net.*</p>
+          <p>Nextcloud is an ideal on-premise file hosting system for diagrams.net.*</p>
           <!-- End Icon Block -->
         </div>
       </div>

--- a/_posts/2018-11-19-import-formats.md
+++ b/_posts/2018-11-19-import-formats.md
@@ -42,7 +42,7 @@ If you are using the draw.io app for Atlassian Confluence, you can even convert 
 diagrams.net works with diagrams and images stored at a number of locations.
 
 - Local storage: in-browser only, or stored on your local hard drive (desktop or mobile).
-- Cloud platforms: Google Drive, OneDrive, NextCloud, and Dropbox.
+- Cloud platforms: Google Drive, OneDrive, Nextcloud, and Dropbox.
 - Github and GitLab.
 
 And because diagrams.net is open source, there is an ever-increasing ecosystem of diagrams.net integrations which support even more storage locations and applications!


### PR DESCRIPTION
Replaces `NextCloud` with `Nextcloud`.

![Nextcloud](https://user-images.githubusercontent.com/1869584/88458249-05b9e180-ce8d-11ea-8d67-d60f0da70b15.png)

 From https://nextcloud.com/blog/are-you-an-enterprise-or-private-user-8-ways-to-get-help-for-any-nextcloud-matter/ 😄 