### PR TITLE
Correct draw.io for Sandstorm link

### DIFF
--- a/pages/integrations.md
+++ b/pages/integrations.md
@@ -71,6 +71,6 @@ The draw.io apps for Confluence and Jira are available via the Atlassian Marketp
 * [**ownCloud:**](https://marketplace.owncloud.com/apps/drawio/) Create and modify diagrams in the ownCloud open-source collaboration platform's file editor app.
 * [**Redmine:**](https://www.redmine.org/plugins/redmine_drawio) Create diagrams in your project documentation in Redmine, a flexible project management web application, based on Ruby on Rails.
 * [**Samepage:**](https://www.samepage.io/draw-diagram-online) Develop diagrams, track tasks, share files, communicate and work on project content without leaving this team collaboration platform.
-* [**Sandstorm:**](https://oasis.sandstorm.io/grain/WiGZtvkCAHj54oX3h4a9Ra) Create personal/private instances of web apps and create diagrams via Sandstorm.io, an open source hosting platform.
+* [**Sandstorm:**](https://apps.sandstorm.io/app/nfqhx83vvzm80edpgkpax8mhqp176qj2vwg67rgq5e3kjc5r4cyh) Create personal/private instances of web apps and create diagrams via Sandstorm.io, an open source hosting platform.
 * [**VS Code:**](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio) Edit and manage diagrams directly inside VS Code.
 * [**XWiki:**](https://extensions.xwiki.org/xwiki/bin/view/Extension/Diagram%20Application) Create diagrams in XWiki, a lightweight wiki software by using the Diagram Application extension.


### PR DESCRIPTION
The link on this page points to a grain on Oasis. This would not have worked when Oasis was up, because it's a grain link not a share link. However, Oasis has also been shut down. Similar to some other integrations, I've linked to the draw.io app page on the Sandstorm App Market, from which people can install it or launch a demo instance of it.